### PR TITLE
Remove the 443 port from the url of the API calls

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -396,7 +396,7 @@ get_data<-
         
         
         
-        url <- paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/getCoreHolder/",
+        url <- paste0("https://ephtracking.cdc.gov/apigateway/api/v1/getCoreHolder/",
                         SL_df_complete[gch,]$measureId,"/",
                         SL_df_complete[gch,]$stratificationLevelId,"/", #stratification level id
                         smoothing, "/",
@@ -414,7 +414,7 @@ get_data<-
         
       }else{
         
-        url  <- paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/getCoreHolder/",
+        url  <- paste0("https://ephtracking.cdc.gov/apigateway/api/v1/getCoreHolder/",
                        SL_df_complete[gch,]$measureId,"/",
                        SL_df_complete[gch,]$stratificationLevelId,"/", #stratification level id
                        smoothing, "/",

--- a/R/list_GeographicItems.R
+++ b/R/list_GeographicItems.R
@@ -67,7 +67,7 @@ list_GeographicItems <- function(measure,
                        function(gg){
                          
                          url <- paste0(
-                           "https://ephtracking.cdc.gov:443/apigateway/api/v1/geographicItems/",
+                           "https://ephtracking.cdc.gov/apigateway/api/v1/geographicItems/",
                            meas_ID[gg],"/",geo_typeID[gg],"/",rollup)
                          
                          if(!is.null(token) & 

--- a/R/list_GeographicTypes.R
+++ b/R/list_GeographicTypes.R
@@ -66,7 +66,7 @@ list_GeographicTypes <- function(measure,
 
   GL_list <- purrr::map( 1:length(meas_ID), function(geolev){
     
-    url <- paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/geographicTypes/",
+    url <- paste0("https://ephtracking.cdc.gov/apigateway/api/v1/geographicTypes/",
                   meas_ID[geolev])
     
     if(!is.null(token) & 

--- a/R/list_StratificationLevels.R
+++ b/R/list_StratificationLevels.R
@@ -87,7 +87,7 @@ list_StratificationLevels <-
           #ephtracking.cdc.gov/apigateway/api/{version}/stratificationlevel/
           # {measureId}/{geographicTypeId}/{isSmoothed}[?apiToken]
           
-          url <- paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/stratificationlevel/",
+          url <- paste0("https://ephtracking.cdc.gov/apigateway/api/v1/stratificationlevel/",
                         GL_list_sub$measureId[i],"/",
                         GL_list_sub$geographicTypeId[i],"/",
                         smoothing)

--- a/R/list_StratificationTypes.R
+++ b/R/list_StratificationTypes.R
@@ -89,7 +89,7 @@ list_StratificationTypes <-
           # ephtracking.cdc.gov/apigateway/api/{version}/stratificationTypes/{measureId}/{geographicTypeId}/
           #   {isSmoothed}[?apiToken]
           
-          url <- paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/stratificationTypes/",
+          url <- paste0("https://ephtracking.cdc.gov/apigateway/api/v1/stratificationTypes/",
                         GL_list_sub$measureId[i],"/",
                         GL_list_sub$geographicTypeId[i],"/",smoothing)
           

--- a/R/list_content_areas.R
+++ b/R/list_content_areas.R
@@ -31,7 +31,7 @@ list_content_areas <- function(token=NULL){
   }
   
   
-  url <- "https://ephtracking.cdc.gov:443/apigateway/api/v1/contentareas/json"
+  url <- "https://ephtracking.cdc.gov/apigateway/api/v1/contentareas/json"
   
   if(!is.null(token) & 
      is.character(token)){

--- a/R/list_geographies.R
+++ b/R/list_geographies.R
@@ -62,7 +62,7 @@ list_geographies<-function(measure=NA,
 
   geo_list <- purrr::map(1:length(meas_ID), 
                        function(gg){
-                         geo<-httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/geography/",
+                         geo<-httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/geography/",
                                                meas_ID[gg],"/",geo_type_ID[gg],"/",rollup))
                          geo_cont<-jsonlite::fromJSON(rawToChar(geo$content))
                          geo_cont$Measure_ID<-meas_ID[gg]

--- a/R/list_geography_types.R
+++ b/R/list_geography_types.R
@@ -58,7 +58,7 @@ list_geography_types<-function(measure=NA,
 
   GL_list<-purrr::map(1:length(meas_ID), function(geolev){
     GL<-
-      httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/geographicLevels/",
+      httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/geographicLevels/",
                  meas_ID[geolev]))
 
     GL_cont<-jsonlite::fromJSON(rawToChar(GL$content))

--- a/R/list_measures.R
+++ b/R/list_measures.R
@@ -56,7 +56,7 @@ list_measures <- function(indicator=NA,
   
   
   
-  measures_url <- "https://ephtracking.cdc.gov:443/apigateway/api/v1/measuresearch"
+  measures_url <- "https://ephtracking.cdc.gov/apigateway/api/v1/measuresearch"
   
   
   if(!is.null(token) & 

--- a/R/list_stratification_levels.R
+++ b/R/list_stratification_levels.R
@@ -63,7 +63,7 @@ list_stratification_levels<-
     SL_list<-purrr::map(1:length(meas_ID), function(strlev){
       
       SL<-
-        httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/stratificationlevel/",
+        httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/stratificationlevel/",
                          meas_ID[strlev],"/",geo_type_ID[strlev],"/",smoothing))
       SL_cont<-jsonlite::fromJSON(rawToChar(SL$content))
       SL_cont$Measure_ID<-meas_ID[strlev]

--- a/R/list_stratification_values.R
+++ b/R/list_stratification_values.R
@@ -68,7 +68,7 @@ list_stratification_values <-
     MS_list<-purrr::map(1:length(meas_ID),function(measstrat){
       
       MS<-
-        httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/measurestratification/",
+        httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/measurestratification/",
                          meas_ID[measstrat],"/",
                          geo_type_ID[measstrat],"/",smoothing))
       

--- a/R/list_temporal.R
+++ b/R/list_temporal.R
@@ -71,7 +71,7 @@ list_temporal <- function(measure=NA,
   temp_list<-purrr::map(1:nrow(geo_parentid_table), function(tp){
     
     temp<-
-      httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/temporal/",
+      httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/temporal/",
                        geo_parentid_table$Measure_ID[tp],"/",
                        geo_parentid_table$Geo_Type_ID[tp],"/",
                        geo_filter,"/",geo_parentid_table$parentGeographicId[tp]))

--- a/R/update_inventory.R
+++ b/R/update_inventory.R
@@ -26,7 +26,7 @@ update_inventory<-function(){
   message("Downloading inventory...")
   
   CAs_raw <-
-    httr::GET("https://ephtracking.cdc.gov:443/apigateway/api/v1/contentareas/json")
+    httr::GET("https://ephtracking.cdc.gov/apigateway/api/v1/contentareas/json")
   CAs<-jsonlite::fromJSON(rawToChar(CAs_raw$content))
   CA_id<-CAs$id
   
@@ -35,7 +35,7 @@ update_inventory<-function(){
   
   inds_list<-list()
   for(ind in 1:length(CA_id)){
-    inds <- httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/indicators/",CA_id[ind]))
+    inds <- httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/indicators/",CA_id[ind]))
     inds_list[[ind]] <- jsonlite::fromJSON(rawToChar(inds$content))
     inds_list[[ind]]$Content_Area <- CA_id[ind]
   }
@@ -49,7 +49,7 @@ update_inventory<-function(){
   meas_list<-list()
   for(mezr in 1:length(ind_id)){
     meas<-
-      httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/measures/",
+      httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/measures/",
                        ind_id[mezr]))
     meas_list[[mezr]]<-jsonlite::fromJSON(rawToChar(meas$content))
     meas_list[[mezr]]$Indicator<-ind_id[mezr]

--- a/data-raw/create_measures_indicators_CAs_inventory.R
+++ b/data-raw/create_measures_indicators_CAs_inventory.R
@@ -2,7 +2,7 @@
 
 
 CAs_raw<-
-  httr::GET("https://ephtracking.cdc.gov:443/apigateway/api/v1/contentareas/json")
+  httr::GET("https://ephtracking.cdc.gov/apigateway/api/v1/contentareas/json")
 CAs<-jsonlite::fromJSON(rawToChar(CAs_raw$content))
 CA_id<-CAs$id
 
@@ -11,7 +11,7 @@ CA_id<-CAs$id
 
 inds_list<-list()
 for(ind in 1:length(CA_id)){
-  inds<-httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/indicators/",CA_id[ind]))
+  inds<-httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/indicators/",CA_id[ind]))
   inds_list[[ind]]<-jsonlite::fromJSON(rawToChar(inds$content))
   inds_list[[ind]]$Content_Area<-CA_id[ind]
 }
@@ -25,7 +25,7 @@ ind_id<-Inds$id
 meas_list<-list()
 for(mezr in 1:length(ind_id)){
   meas<-
-    httr::GET(paste0("https://ephtracking.cdc.gov:443/apigateway/api/v1/measures/",
+    httr::GET(paste0("https://ephtracking.cdc.gov/apigateway/api/v1/measures/",
                      ind_id[mezr]))
   meas_list[[mezr]]<-jsonlite::fromJSON(rawToChar(meas$content))
   meas_list[[mezr]]$Indicator<-ind_id[mezr]


### PR DESCRIPTION
Remove the 443 port from the url of the API calls. For some reason this is causing problems for some users.